### PR TITLE
Fix bold

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -117,6 +117,7 @@ i {
 
 b {
   color: var(--orange);
+  font-weight: bold;
 }
 
 mark {


### PR DESCRIPTION
Bold text (e.g. Markdown `**like this**`) was not displaying as bold. Logseq 0.7.3