### PR TITLE
Fix five things

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -287,6 +287,9 @@ html[data-theme="dark"] .CodeMirror .CodeMirror-gutter {
   /* Background color for the line numbers displayed on the left */
   background: var(--background);
 }
+html[data-theme="dark"] .CodeMirror .CodeMirror-hscrollbar {
+  margin: 4px;
+}
 html[data-theme="dark"] .CodeMirror .CodeMirror-selected {
   background: rgba(255, 255, 255, 0.1);
 }

--- a/custom.css
+++ b/custom.css
@@ -2,6 +2,7 @@
 
 :root {
   --background: #282a36;
+  --background-code: #1a1e24;
   --light-background: #343746;
   --lighter-background: #424450;
   --dark-background: #21222c;
@@ -84,7 +85,7 @@ html[data-theme="dark"] {
   --ls-page-properties-background-color: var(--light-background);
 
   --ls-page-inline-code-color: var(--green);
-  --ls-page-inline-code-bg-color: var(--background);
+  --ls-page-inline-code-bg-color: var(--background-code);
 
   --ls-scrollbar-background-color: var(--background);
   --ls-scrollbar-foreground-color: var(--darker-background);

--- a/custom.css
+++ b/custom.css
@@ -283,6 +283,10 @@ html[data-theme="dark"] .CodeMirror .CodeMirror-cursor {
 html[data-theme="dark"] .CodeMirror .CodeMirror-linenumber {
   color: var(--comment);
 }
+html[data-theme="dark"] .CodeMirror .CodeMirror-gutter {
+  /* Background color for the line numbers displayed on the left */
+  background: var(--background);
+}
 html[data-theme="dark"] .CodeMirror .CodeMirror-selected {
   background: rgba(255, 255, 255, 0.1);
 }

--- a/custom.css
+++ b/custom.css
@@ -270,10 +270,16 @@ html[data-theme="dark"] .extensions__code-lang {
 }
 
 html[data-theme="dark"] #main-content-container code {
-  background: var(--light-background);
+  background: var(--darker-background);
+}
+html[data-theme="dark"] #main-content-container .selected code {
+  background: var(--background);
 }
 html[data-theme="dark"] #right-sidebar-container code {
   background: var(--light-background);
+}
+html[data-theme="dark"] #right-sidebar-container .selected code {
+  background: var(--background);
 }
 
 html[data-theme="dark"] .CodeMirror {

--- a/custom.css
+++ b/custom.css
@@ -420,3 +420,9 @@ progress::-webkit-progress-value {
 .editor-inner .uniline-block:is(.h1,.h2), .ls-block :is(h1,h2) {
     border-bottom: none;
 }
+
+/* Make "New page" button opaque */
+html[data-theme="dark"] .new-page-link {
+  background: var(--background);
+  opacity: 1;
+}

--- a/custom.css
+++ b/custom.css
@@ -2,7 +2,6 @@
 
 :root {
   --background: #282a36;
-  --background-code: #1a1e24;
   --light-background: #343746;
   --lighter-background: #424450;
   --dark-background: #21222c;
@@ -85,7 +84,7 @@ html[data-theme="dark"] {
   --ls-page-properties-background-color: var(--light-background);
 
   --ls-page-inline-code-color: var(--green);
-  --ls-page-inline-code-bg-color: var(--background-code);
+  --ls-page-inline-code-bg-color: var(--background);
 
   --ls-scrollbar-background-color: var(--background);
   --ls-scrollbar-foreground-color: var(--darker-background);
@@ -267,6 +266,13 @@ html[data-theme="dark"] .CodeMirror .CodeMirror-gutters {
 }
 
 html[data-theme="dark"] .extensions__code-lang {
+  background: var(--light-background);
+}
+
+html[data-theme="dark"] #main-content-container code {
+  background: var(--light-background);
+}
+html[data-theme="dark"] #right-sidebar-container code {
   background: var(--light-background);
 }
 

--- a/custom.css
+++ b/custom.css
@@ -283,6 +283,11 @@ html[data-theme="dark"] .CodeMirror .CodeMirror-cursor {
 html[data-theme="dark"] .CodeMirror .CodeMirror-linenumber {
   color: var(--comment);
 }
+html[data-theme="dark"] .CodeMirror .CodeMirror-activeline .CodeMirror-linenumber {
+  /* Color of line number where the cursor is present */
+  color: var(--comment);
+  filter: brightness(1.4);
+}
 html[data-theme="dark"] .CodeMirror .CodeMirror-gutter {
   /* Background color for the line numbers displayed on the left */
   background: var(--background);


### PR DESCRIPTION
**Fixes** https://github.com/dracula/logseq/issues/15

The color used is `#1a1e24`
Source: https://github.com/dracula/obsidian/blob/main/obsidian.css#L4

**Before**
![image](https://user-images.githubusercontent.com/42742240/213866362-4889960e-4101-4e45-8717-33cefb828cab.png)
![image](https://user-images.githubusercontent.com/42742240/214802287-c988d90e-e2cc-408e-8e65-b812163a1ea7.png)

**After**
![image](https://user-images.githubusercontent.com/42742240/214802000-ee2a68e6-32c7-444d-b557-aa3023137ffd.png)
![image](https://user-images.githubusercontent.com/42742240/214802114-0f796763-2da8-4599-a5ce-13a6c973c24a.png)

---

1. Absence of background color for line numbers in code block resulted in text overlap
2. Added padding to scroll bar
3. Made line number of active line brighter
4. Another demonstration of point 2
5. Background color added to "New page" button

**Before**
![image](https://user-images.githubusercontent.com/42742240/213866479-2bf31a7d-eefb-4f6d-bc3e-97927fbd6d02.png)
![image](https://user-images.githubusercontent.com/42742240/213866751-7d630512-1f49-4df2-9679-fb095b65e27e.png)
![image](https://user-images.githubusercontent.com/42742240/214776369-3ca1e6a2-fca6-48dc-b0a8-8b727cd9e25c.png)
![image](https://user-images.githubusercontent.com/42742240/214776440-d7b33ed5-2527-4c16-ac4a-b9ce0fc97a2d.png)

**After**
![image](https://user-images.githubusercontent.com/42742240/213866612-9f42ac6a-19c2-4218-9dd4-73fa3c3c9968.png)
![image](https://user-images.githubusercontent.com/42742240/213866817-1d10a110-31b3-4c8a-81fc-89971739833a.png)
![image](https://user-images.githubusercontent.com/42742240/214776229-59155b0a-29f7-4278-b2eb-8101e2cd4db3.png)
![image](https://user-images.githubusercontent.com/42742240/214776698-e6a7465d-4799-48f2-b0eb-8ca1b21a36bb.png)
