### PR TITLE
Issue #23: Apply root variables at html level

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -1,6 +1,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Fira+Sans:ital,wght@0,300;0,400;0,500;1,300;1,400;1,500&display=swap');
 
-:root {
+.dark-theme,
+html[data-theme="dark"] {
   --background: #282a36;
   --light-background: #343746;
   --lighter-background: #424450;
@@ -34,10 +35,7 @@
 
   --ls-border-radius-low: 3px;
   --ls-border-radius-medium: 6px;
-}
 
-.dark-theme,
-html[data-theme="dark"] {
   --foreground: var(--white);
 
   --ls-primary-background-color: var(--background);


### PR DESCRIPTION
This prevents the app's dark theme styles in recent versions from overwriting it.

## Before

<img width="1014" alt="Screenshot 2024-05-28 at 10 32 23 AM" src="https://github.com/dracula/logseq/assets/687315/4f176813-fc72-4602-bf70-c3e6879f6566">


## After
<img width="1040" alt="Screenshot 2024-05-28 at 10 32 48 AM" src="https://github.com/dracula/logseq/assets/687315/4ba64c8a-ca8e-4b3f-8490-bf391e23b976">

This should address the issues raised in #23.
